### PR TITLE
Stand in Timeline

### DIFF
--- a/client/roadmap.html
+++ b/client/roadmap.html
@@ -128,10 +128,10 @@
                         </div>
                         <!-- cd-timeline-img -->
                         <div class="cd-timeline-content">
-                            <h2>Early access token presale</h2>
-                            <p>If hard cap not met then public ICO May 24th.</p>
-                            <p>Start of integration of Ephemeral messaging layer to enable end-end secure data channels</p>
-                            <span class="cd-date">May 2017</span>
+                             <h2>Funding targets achieved</h2>
+                             <p>Public ICO no longer required</p>
+                             <p>Start of integration of Ephemeral messaging layer to enable end-end secure data channels</p>
+                             <span class="cd-date">May 2017</span>
                         </div>
                     </div>
                     <!-- cd-timeline-block -->
@@ -150,7 +150,7 @@
                     <div class="cd-timeline-block">
                         <div class="cd-timeline-img cd-picture"><img src="pq-sertificates.png" alt="Location"></div>
                         <div class="cd-timeline-content">
-                            <h2>Ongoing Testing & Development</h2>
+                            <h2>Ongoing Testing &amp; Development</h2>
                             <p>Web Wallet + other GUI work</p>
                             <p>Further Optimizations</p>
                             <p>Preparing for security testnet</p>

--- a/client/roadmap.html
+++ b/client/roadmap.html
@@ -148,7 +148,7 @@
                         </div>
                     </div>
                     <div class="cd-timeline-block">
-                        <div class="cd-timeline-img cd-picture"><img src="assets/pq-sertificates.png" alt="Location"></div>
+                        <div class="cd-timeline-img cd-picture"><img src="pq-sertificates.png" alt="Location"></div>
                         <div class="cd-timeline-content">
                             <h2>Ongoing Testing & Development</h2>
                             <p>Web Wallet + other GUI work</p>
@@ -157,7 +157,7 @@
                             <span class="cd-date"><h2>&#x2190; We Are Here</h2></span></div>
                     </div>
                     <div class="cd-timeline-block">
-                        <div class="cd-timeline-img cd-picture"><img src="assets/vulnerability.png" alt="Location"></div>
+                        <div class="cd-timeline-img cd-picture"><img src="vulnerability.png" alt="Location"></div>
                         <div class="cd-timeline-content">
                             <h2>Security Testing</h2>
                             <p>Bug Bounty Program</p>

--- a/client/roadmap.html
+++ b/client/roadmap.html
@@ -147,6 +147,23 @@
                             <span class="cd-date">June 2017</span>
                         </div>
                     </div>
+                    <div class="cd-timeline-block">
+                        <div class="cd-timeline-img cd-picture"><img src="assets/pq-sertificates.png" alt="Location"></div>
+                        <div class="cd-timeline-content">
+                            <h2>Ongoing Testing & Development</h2>
+                            <p>Web Wallet + other GUI work</p>
+                            <p>Further Optimizations</p>
+                            <p>Preparing for security testnet</p>
+                            <span class="cd-date"><h2>&#x2190; We Are Here</h2></span></div>
+                    </div>
+                    <div class="cd-timeline-block">
+                        <div class="cd-timeline-img cd-picture"><img src="assets/vulnerability.png" alt="Location"></div>
+                        <div class="cd-timeline-content">
+                            <h2>Security Testing</h2>
+                            <p>Bug Bounty Program</p>
+                            <p>External Auditing</p>
+                            <span class="cd-date"></span></div>
+                    </div>
                     <!-- cd-timeline-block -->
                     <div class="cd-timeline-block">
                         <div class="cd-timeline-img cd-picture">
@@ -155,7 +172,9 @@
                         <!-- cd-timeline-img -->
                         <div class="cd-timeline-content">
                             <h2>Genesis block</h2>
-                            <span class="cd-date">September 2017</span>
+                            <p>To come after thorough testing and auditing</p>
+                            <p>1:1 Conversion of QRL (ERC 20) tokens to Official QRL</p>
+                            <span class="cd-date"></span>
                         </div>
                     </div>
                     <!-- cd-timeline-block -->
@@ -172,7 +191,7 @@
                             <p>Light client API to enable apps and web enabled devices to access the QRL</p>
                             <p>Internode messaging compression</p>
                             <p>Research and development - post-quantum multi-signature transactions</p>
-                            <span class="cd-date">October 2017-2018</span>
+                            <span class="cd-date">2017-2018</span>
                         </div>
                     </div>
                     <!-- cd-timeline-block -->


### PR DESCRIPTION
This is a stand-in until we get the actual timeline up and running feeding off of github as proposed in slack. People are at a very frequent rate coming in and getting (understandably frustrated) about no mainnet existing when it's suggested it was last month.

- Added Security Testing section
- Added further testing & development section
- Removed dates with exception to a few in the far future with years only. 
- Changed icons to what's in assets